### PR TITLE
Update k8s tools to auto-detect API and namespace for deployed instances

### DIFF
--- a/chat_server/server_config.py
+++ b/chat_server/server_config.py
@@ -93,11 +93,12 @@ class KlatServerConfig(KlatConfigurationBase):
     def k8s_api(self):
         if not self._k8s_api:
             if _k8s_config_path := self.k8s_config.get("K8S_CONFIG_PATH"):
+                # Configured path may be used for local deployments
                 config.load_kube_config(_k8s_config_path)
-                self._k8s_api = client.AppsV1Api()
-            raise MalformedConfigurationException(
-                message="'K8S_CONFIG_PATH' property is missing in 'K8S_CONFIG'"
-            )
+            else:
+                # Deployed instances should discover/authenticate automatically
+                config.load_kube_config()
+            self._k8s_api = client.AppsV1Api()
         return self._k8s_api
 
     @property

--- a/chat_server/server_utils/k8s_utils.py
+++ b/chat_server/server_utils/k8s_utils.py
@@ -41,8 +41,14 @@ def restart_deployment(deployment_name: str, namespace: str = None):
     :param namespace: name of the namespace
     """
     if not namespace:
-        namespace = server_config.k8s_default_namespace
-    now = datetime.datetime.utcnow()
+        try:
+            with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+                      "r") as f:
+                namespace = f.read()
+        except Exception as e:
+            LOG.info(e)
+            namespace = server_config.k8s_default_namespace
+    now = datetime.datetime.now(datetime.timezone.utc)
     now = str(now.isoformat() + "Z")
     body = {
         "spec": {


### PR DESCRIPTION
# Description
For deployed instances, the namespace can be determined at runtime instead of reading from config
According to [k8s documentation](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/), it should be possible to automatically authenticate from a deployed container without any extra config.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
I noticed today that the "restart chatbots" button within the Klat Admin application did not restart any deployments (alpha)